### PR TITLE
Fix definition of findbb function

### DIFF
--- a/core.h
+++ b/core.h
@@ -46,6 +46,6 @@ INS** riscv_parse(char* filename, int* ret_sz);
  * output ret_sz: number of outputs 
  * output: basic blocks
  */
-INS*** findbb(INS** ins, int ins_sz, int* ret_sz);
+INS*** findbb(INS** ins_arr, int ins_arr_sz, int** ret_sz);
 
 #endif

--- a/core.h
+++ b/core.h
@@ -18,8 +18,7 @@ typedef struct ins {
   int is_leader;
 } INS;
 
-/*
- * split the dumped asm file into small routines and store to files
+/* split the dumped asm file into small routines and store to files
  * params filename: filname of the large file
  * params type: specify type of asm, 0 for RISC-V, 1 for Arm
  * output ret_sz: number of outputs 
@@ -27,28 +26,26 @@ typedef struct ins {
  */
 char** split_routine(char* filename, int type, int* ret_sz);
 
-/*
- * parse Arm asm file
+/* parse Arm asm file
  * params filename: filname of the routine file 
  * output ret_sz: number of outputs 
  * output: instructions array of the routine
  */
 INS** aarch_parse(char* filename, int* ret_sz);
 
-/*
- * parse RISC-V asm file
+/* parse RISC-V asm file
  * params filename: filname of the routine file 
  * output ret_sz: number of outputs 
  * output: instructions array of the routine
  */
 INS** riscv_parse(char* filename, int* ret_sz);
 
-/*
- * find the basic block from instructions
- * params instructions: instruction array of a routine
+/* find the basic block from instructions
+ * params ins: instruction array of a routine
+ * params ins_sz: size of the instruction array
  * output ret_sz: number of outputs 
  * output: basic blocks
  */
-INS*** findbb(INS* instructions, int* ret_sz);
+INS*** findbb(INS** ins, int ins_sz, int* ret_sz);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -11,15 +11,16 @@ int main(int argc, char** argv) {
   char* filenames[2];
   char** subnames[2];
   int fcount = 0;
-  int ret_sz = 0;
+  // int ret_sz = 0;
 
   for (int i = 0; i < 2; ++i) {
     filenames[i] = argv[i + 1];
     subnames[i] = split_routine(filenames[i], i, &fcount);
     for (int j = 0; j < fcount; ++j) { 
-      INS** ins = (i == 0)? riscv_parse(subnames[i][j], &ret_sz) :
-          aarch_parse(subnames[i][j], &ret_sz);
-      INS*** bb = findbb(*ins, &ret_sz);
+      int ins_arr_sz, *bb_sz;
+      INS** ins_arr = (i == 0)? riscv_parse(subnames[i][j], &ins_arr_sz) :
+          aarch_parse(subnames[i][j], &ins_arr_sz);
+      INS*** bb = findbb(ins_arr, ins_arr_sz, &bb_sz);
     }
   }
   return 0;


### PR DESCRIPTION
The function `findbb` would require also the size of input instruction array, so param `ins_sz` was added. Also, the comment
style was updated.

 I replaced the parameter name `instructions` with simply `ins`. I don't know if it is OK? Or how about `ins_arr`?