### PR TITLE
Revert "Fix definition of findbb function"

### DIFF
--- a/core.h
+++ b/core.h
@@ -18,7 +18,8 @@ typedef struct ins {
   int is_leader;
 } INS;
 
-/* split the dumped asm file into small routines and store to files
+/*
+ * split the dumped asm file into small routines and store to files
  * params filename: filname of the large file
  * params type: specify type of asm, 0 for RISC-V, 1 for Arm
  * output ret_sz: number of outputs 
@@ -26,26 +27,28 @@ typedef struct ins {
  */
 char** split_routine(char* filename, int type, int* ret_sz);
 
-/* parse Arm asm file
+/*
+ * parse Arm asm file
  * params filename: filname of the routine file 
  * output ret_sz: number of outputs 
  * output: instructions array of the routine
  */
 INS** aarch_parse(char* filename, int* ret_sz);
 
-/* parse RISC-V asm file
+/*
+ * parse RISC-V asm file
  * params filename: filname of the routine file 
  * output ret_sz: number of outputs 
  * output: instructions array of the routine
  */
 INS** riscv_parse(char* filename, int* ret_sz);
 
-/* find the basic block from instructions
- * params ins: instruction array of a routine
- * params ins_sz: size of the instruction array
+/*
+ * find the basic block from instructions
+ * params instructions: instruction array of a routine
  * output ret_sz: number of outputs 
  * output: basic blocks
  */
-INS*** findbb(INS** ins_arr, int ins_arr_sz, int** ret_sz);
+INS*** findbb(INS* instructions, int* ret_sz);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -11,16 +11,15 @@ int main(int argc, char** argv) {
   char* filenames[2];
   char** subnames[2];
   int fcount = 0;
-  // int ret_sz = 0;
+  int ret_sz = 0;
 
   for (int i = 0; i < 2; ++i) {
     filenames[i] = argv[i + 1];
     subnames[i] = split_routine(filenames[i], i, &fcount);
     for (int j = 0; j < fcount; ++j) { 
-      int ins_arr_sz, *bb_sz;
-      INS** ins_arr = (i == 0)? riscv_parse(subnames[i][j], &ins_arr_sz) :
-          aarch_parse(subnames[i][j], &ins_arr_sz);
-      INS*** bb = findbb(ins_arr, ins_arr_sz, &bb_sz);
+      INS** ins = (i == 0)? riscv_parse(subnames[i][j], &ret_sz) :
+          aarch_parse(subnames[i][j], &ret_sz);
+      INS*** bb = findbb(*ins, &ret_sz);
     }
   }
   return 0;


### PR DESCRIPTION
Reverts choucl/riscv-arm-asm-comparator#3
`findbb()` function params need to be modified