### PR TITLE
Modify output msg and fix some bugs

### DIFF
--- a/code_analyzer.c
+++ b/code_analyzer.c
@@ -126,8 +126,8 @@ INS ***findbb(INS **ins_arr, int ins_arr_sz, int *ret_sz, int **ret_bb_sz) {
   } 
 
   *ret_sz = bb_idx;
-  INS ***tmp_bb_list = realloc(bb_list, max_ret_sz * sizeof(INS **));  // shrink
-  int *tmp_bb_sz = realloc(bb_sz, max_ret_sz * sizeof(int));           // shrink
+  INS ***tmp_bb_list = realloc(bb_list, *ret_sz * sizeof(INS **));  // shrink
+  int *tmp_bb_sz = realloc(bb_sz, *ret_sz * sizeof(int));           // shrink
   if (tmp_bb_list)
     bb_list = tmp_bb_list;
   if (tmp_bb_sz)

--- a/main.c
+++ b/main.c
@@ -44,7 +44,7 @@ static int writebb(INS*** bb, int bb_count, int* bb_len, int type, char* name) {
     free(tmp);
     return 0;
   }
-  printf("[writing] %s\n", fname);
+  printf("[Writing] %s\n", fname);
 
   // write instruction and bb data into file
   for (int i = 0; i < bb_count; ++i) {
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
     subnames[i] = split_routine(filenames[i], i, &fcount);
     for (int j = 0; j < fcount; ++j) { 
       int ins_arr_sz, bb_count, *bb_sz;
-      printf("[parsing] %s\n", subnames[i][j]);
+      printf("[Parsing] %s\n", subnames[i][j]);
       INS** ins_arr = (i == 0)? riscv_parse(subnames[i][j], &ins_arr_sz):
                                 aarch_parse(subnames[i][j], &ins_arr_sz);
       INS*** bb = findbb(ins_arr, ins_arr_sz, &bb_count, &bb_sz);

--- a/main.c
+++ b/main.c
@@ -44,7 +44,7 @@ static int writebb(INS*** bb, int bb_count, int* bb_len, int type, char* name) {
     free(tmp);
     return 0;
   }
-  printf("[Writing] %s\n", fname);
+  printf("[Writing]\t%s\n", fname);
 
   // write instruction and bb data into file
   for (int i = 0; i < bb_count; ++i) {
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
     subnames[i] = split_routine(filenames[i], i, &fcount);
     for (int j = 0; j < fcount; ++j) { 
       int ins_arr_sz, bb_count, *bb_sz;
-      printf("[Parsing] %s\n", subnames[i][j]);
+      printf("[Parsing]\t%s\n", subnames[i][j]);
       INS** ins_arr = (i == 0)? riscv_parse(subnames[i][j], &ins_arr_sz):
                                 aarch_parse(subnames[i][j], &ins_arr_sz);
       INS*** bb = findbb(ins_arr, ins_arr_sz, &bb_count, &bb_sz);

--- a/riscv_parser.c
+++ b/riscv_parser.c
@@ -76,7 +76,6 @@ static int title() {
   char *name = NULL;
 
   if (hex(&val) && lbl_name(&name) && match(':') && match('\n')) {
-     printf("Parsing routine: %s @0x%x\n", name, val);
      free(name);
      return 1;
   }

--- a/split_subroutine.c
+++ b/split_subroutine.c
@@ -30,7 +30,7 @@ char** split_routine(char* filename, int type, int* ret_sz) {
         // set up file name
         char* tmp = strdup(name);
         sprintf(name, "subroutines/%s.%s.o", tmp, (type)? "aarch" : "riscv");
-        printf("[spliting] %s\n",name);
+        printf("[Spliting] %s\n",name);
         subnames[(*ret_sz)] = calloc(strlen(name) + 1, sizeof(char));
         strncpy(subnames[(*ret_sz)++], name, strlen(name) + 1);
         fo = fopen(name, "w+");

--- a/split_subroutine.c
+++ b/split_subroutine.c
@@ -30,7 +30,7 @@ char** split_routine(char* filename, int type, int* ret_sz) {
         // set up file name
         char* tmp = strdup(name);
         sprintf(name, "subroutines/%s.%s.o", tmp, (type)? "aarch" : "riscv");
-        printf("[Spliting] %s\n",name);
+        printf("[Spliting]\t%s\n",name);
         subnames[(*ret_sz)] = calloc(strlen(name) + 1, sizeof(char));
         strncpy(subnames[(*ret_sz)++], name, strlen(name) + 1);
         fo = fopen(name, "w+");
@@ -52,6 +52,7 @@ char** split_routine(char* filename, int type, int* ret_sz) {
           // set up file name
           char* tmp = strdup(name);
           sprintf(name, "subroutines/%s.%s.o", tmp, (type)? "aarch" : "riscv");
+          printf("[Spliting]\t%s\n",name);
           subnames[(*ret_sz)] = calloc(strlen(name) + 1, sizeof(char));
           strncpy(subnames[(*ret_sz)++], name, strlen(name) + 1);
           fo = fopen(name, "w+");


### PR DESCRIPTION
The realloc volume size is incorrect in code_analyzer.c, but now it has been corrected. Capitalize the first letter of the label in brackets in all output messages. Remove printing from riscv_parser.c